### PR TITLE
Update Qsettings to use new name/company associated with mdwizard version

### DIFF
--- a/pymdwizard/core/utils.py
+++ b/pymdwizard/core/utils.py
@@ -579,7 +579,7 @@ def get_setting(which, default=None):
         setting in native format, string, integer, etc
 
     """
-    settings = QSettings("USGS", "pymdwizard")
+    settings = QSettings("USGS_2.0.7", "pymdwizard_2.0.7")
     if default is None:
         return settings.value(which)
     else:

--- a/pymdwizard/gui/MainWindow.py
+++ b/pymdwizard/gui/MainWindow.py
@@ -109,7 +109,7 @@ class PyMdWizardMainForm(QMainWindow):
     def __init__(self, parent=None):
         super(self.__class__, self).__init__()
 
-        self.settings = QSettings("USGS", "pymdwizard")
+        self.settings = QSettings("USGS_2.0.7", "pymdwizard_2.0.7")
         self.cur_fname = ""
         self.file_watcher = None
 

--- a/pymdwizard/gui/detailed.py
+++ b/pymdwizard/gui/detailed.py
@@ -103,7 +103,7 @@ class Detailed(WizardWidget):  #
         self.ui.fgdc_enttypds.setText(default_def_source)
 
     def browse(self):
-        settings = QSettings("USGS", "pymdwizard")
+        settings = QSettings("USGS_2.0.7", "pymdwizard_2.0.7")
         last_data_fname = settings.value("lastDataFname", "")
         if last_data_fname:
             dname, fname = os.path.split(last_data_fname)

--- a/pymdwizard/gui/settings.py
+++ b/pymdwizard/gui/settings.py
@@ -85,7 +85,7 @@ class Settings(QWidget):
         self.ui.btn_save.clicked.connect(self.save_settings)
 
     def load_settings(self):
-        self.settings = QSettings("USGS", "pymdwizard")
+        self.settings = QSettings("USGS_2.0.7", "pymdwizard_2.0.7")
         template_fname = self.settings.value("template_fname")
 
         if template_fname is None:

--- a/pymdwizard/gui/spatial_tab.py
+++ b/pymdwizard/gui/spatial_tab.py
@@ -98,7 +98,7 @@ class SpatialTab(WizardWidget):
         self.clear_widget()
 
     def browse(self):
-        settings = QSettings("USGS", "pymdwizard")
+        settings = QSettings("USGS_2.0.7", "pymdwizard_2.0.7")
         last_data_fname = settings.value("lastDataFname", "")
         if last_data_fname:
             dname, fname = os.path.split(last_data_fname)

--- a/tests/test_mainwindow.py
+++ b/tests/test_mainwindow.py
@@ -98,7 +98,7 @@ def test_misc(qtbot, mock):
 
 def test_settings(qtbot, mock):
 
-    settings = qt_api.QtCore.QSettings("USGS", "pymdwizard")
+    settings = qt_api.QtCore.QSettings("USGS_2.0.7", "pymdwizard_2.0.7")
     settings.setValue("template_fname", "tests/data/USGS_ASC_PolarBears_FGDC.xml")
 
     widget = MainWindow.PyMdWizardMainForm()


### PR DESCRIPTION
Some values are stored via Qsettings in python and I wanted to start from a blank slate so that no errors are thrown in the new version.  Some paths have changed since the python upgrade / reorganization of envs and files.